### PR TITLE
Fail resistance for invalid JSON lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,19 @@ var split     = require('split2')
   , duplexer  = require('reduplexer')
   , through   = require('through2')
 
+function jsonParse (line)
+{
+  var rv = {}
+  try {
+    rv = JSON.parse(line)
+  } catch (err) {
+    rv.err = err 
+  }
+}
+
 function lineDelimitedJSON(duplex) {
 
-  var readable  = duplex.pipe(split(JSON.parse))
+  var readable  = duplex.pipe(split(jsonParse))
     , writable  = through({ objectMode: true }, function(chunk, enc, cb) {
                     this.push(JSON.stringify(chunk), 'utf8')
                     this.push('\n', 'utf8')

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function jsonParse (line)
   } catch (err) {
     rv.err = err 
   }
+  return rv
 }
 
 function lineDelimitedJSON(duplex) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ function jsonParse (line)
     rv = JSON.parse(line)
   } catch (err) {
     rv.err = err 
+    rv.line = line
   }
   return rv
 }

--- a/test.js
+++ b/test.js
@@ -56,3 +56,17 @@ test('ldj works with net streams', function(t) {
     })
   })
 })
+
+test('ldj accepts plain strings / invalid json', function(t) {
+  t.plan(1)
+
+  var binary    = ps()
+    , instance  = ldj(binary)
+    , msg       = 'test'
+
+  instance.on('data', function(chunk) {
+    t.deepEqual(chunk, msg)
+  })
+
+  instance.end(msg)
+})


### PR DESCRIPTION
In real life it can happen that a single line might be broken and the next line contains again valid JSON - in this case the program crashes when a line is invalid. My goal is to have a fail tolerant parser. 

I could not register an error handler at the right place using the module. All error handlers on socket, client, returned reduplexer object did not catch the JSON parse error in the split() method (!). 
Therefore my program crashed on invalid JSON lines. 

My solution is to catch JSON parse errors, and the parser can continue with the next line, which might be valid again. It works fine for me. The errors and original line are wrapped into the resulting object, so users could check for .err property and throw an own error, log it or respond to client ....
